### PR TITLE
revert when oracles return 0 price & adjust test cases

### DIFF
--- a/contracts/oracles/PythOracle.sol
+++ b/contracts/oracles/PythOracle.sol
@@ -101,7 +101,7 @@ contract PythOracle is OracleInterface, Ownable {
      * @return price in 10 decimals
      */
     function getUnderlyingPrice(address vToken) external view override returns (uint256) {
-        require(address(underlyingPythOracle) != address(0), "pyth oracle is zero address");
+        require(address(underlyingPythOracle) != address(0), "Pyth oracle is zero address");
         TokenConfig storage tokenConfig = tokenConfigs[vToken];
         require(tokenConfig.vToken != address(0), "vToken doesn't exist");
 
@@ -112,6 +112,8 @@ contract PythOracle is OracleInterface, Ownable {
         );
         
         uint256 price = int256(priceInfo.price).toUint256();
+
+        require(price > 0, "Pyth oracle price must be positive");
         
         // the price returned from Pyth is price ** 10^expo, which is the real dollar price of the assets
         // we need to multiply it by 1e18 to make the price 18 decimals

--- a/contracts/oracles/TwapOracle.sol
+++ b/contracts/oracles/TwapOracle.sol
@@ -132,7 +132,11 @@ contract TwapOracle is Ownable, OracleInterface {
      */
     function getUnderlyingPrice(address vToken) external override view returns (uint256) {
         require(tokenConfigs[vToken].vToken != address(0), "vToken not exist");
-        return prices[vToken];
+        uint256 price = prices[vToken];
+
+        // if price is 0, it means the price hasn't been updated yet and it's meaningless, revert
+        require(price > 0, "TWAP price must be positive"); 
+        return price;
     }
 
     /**

--- a/test/PivotTwapOracle.ts
+++ b/test/PivotTwapOracle.ts
@@ -229,6 +229,11 @@ describe("Twap Oracle unit tests", function () {
         this.twapOracle.getUnderlyingPrice(addr1111)
       ).to.be.revertedWith("vToken not exist");
     });
+    it('revert if get underlying price of token has not been updated', async function () {
+      await expect(
+        this.twapOracle.getUnderlyingPrice(this.token0)
+      ).to.be.revertedWith("TWAP price must be positive");
+    });
     it('twap window update', async function () {
       const ts = await getTime();
       const token0 = await this.simplePair.token0();

--- a/test/PythOracle.ts
+++ b/test/PythOracle.ts
@@ -186,7 +186,7 @@ describe("Oracle plugin frame unit tests", function () {
       ).to.be.revertedWith("No available price within given duration");
     })
 
-    it('revert when price is negative (just in case Pyth return insane data)', async function () {
+    it('revert when price is not positive (just in case Pyth return insane data)', async function () {
       const ts = await getTime();
       const feed = {
         id: getBytes32String(3),
@@ -216,6 +216,12 @@ describe("Oracle plugin frame unit tests", function () {
       await expect(
         this.pythOracle.getUnderlyingPrice(addr1111)
       ).to.be.revertedWith("SafeCast: value must be positive");
+
+      feed.price = BigNumber.from(0);
+      await this.underlyingPythOracle.updatePriceFeedsHarness([feed]);
+      await expect(
+        this.pythOracle.getUnderlyingPrice(addr1111)
+      ).to.be.revertedWith("Pyth oracle price must be positive");
     })
 
     it('price should be 18 decimals', async function () {


### PR DESCRIPTION
## Description

Right now we return 0 to Comptroller to indicate something is wrong, and Comptroller won’t do anything and return an error code to the users.
it’s more clear to just revert it and the frontend can know better what’s happening instead of staring at a successfully mined meaningless transaction, moreover, this can prevent some potential risk


## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
