### PR TITLE
Add price oracle interface

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,7 @@
   "extends": "solhint:recommended",
   "rules": {
     "code-complexity": ["error", 8],
-    "compiler-version": ["error", "^0.8.0"],
+    "compiler-version": ["error", ">=0.5.0"],
     "const-name-snakecase": "off",
     "constructor-syntax": "error",
     "func-visibility": ["error", { "ignoreConstructors": true }],

--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.16;
+
+contract PriceOracle {
+    /// @notice Indicator that this is a PriceOracle contract (for inspection)
+    bool public constant isPriceOracle = true;
+
+    /**
+     * @notice Get the underlying price of a vToken asset
+     * @param vToken The vToken address to get the underlying price of
+     * @return The underlying asset price mantissa (scaled by 1e18).
+     *  Zero means the price is unavailable.
+     */
+    function getUnderlyingPrice(address vToken) external view returns (uint256);
+
+    function updatePrice(address vToken) external;
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -92,24 +92,36 @@ const config: HardhatUserConfig = {
     tests: "./test",
   },
   solidity: {
-    version: "0.8.13",
-    settings: {
-      metadata: {
-        // Not including the metadata hash
-        // https://github.com/paulrberg/solidity-template/issues/31
-        bytecodeHash: "none",
-      },
-      // Disable the optimizer when debugging
-      // https://hardhat.org/hardhat-network/#solidity-optimizer-support
-      optimizer: {
-        enabled: true,
-      },
-      outputSelection: {
-        "*": {
-          "*": ["storageLayout"],
+    compilers: [
+      {
+        version: "0.8.13",
+        settings: {
+          // Disable the optimizer when debugging
+          // https://hardhat.org/hardhat-network/#solidity-optimizer-support
+          optimizer: {
+            enabled: true,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         },
       },
-    },
+      {
+        version: "0.5.16",
+        settings: {
+          optimizer: {
+            enabled: true,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
+        },
+      },
+    ],
   },
   typechain: {
     outDir: "src/types",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@venusprotocol/oracle",
   "description": "Venus Protocol Price Oracle",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "",
   "files": [
     "artifacts",


### PR DESCRIPTION
## Description
Adding a PriceOracle interface to be consumed by other repos.
This will make it easier to keep the interface updated between projects.

The contract can be imported  as follows
```import "@venusprotocol/oracle/contracts/PriceOracle.sol";```