### PR TITLE
fix: refactoring resilient oracle

### DIFF
--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -214,9 +214,9 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
             } catch {}
         }
 
-        // Compare main price and pivot price, return main price and if validation was succesfull
+        // Compare main price and pivot price, return main price and if validation was successfull
         // note: In case pivot oracle is not available and main price is available,
-        // validation is succesfull and main oracle price is returned.
+        // validation is successfull and main oracle price is returned.
         (uint256 mainPrice, bool validatedPivotMain) = _getMainOraclePrice(
             vToken,
             pivotPrice,
@@ -251,7 +251,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @param pivotEnabled if pivot oracle is not empty and enabled
      * @return price USD price in scaled decimals
      * @return pivotValidated Boolean representing if the validation of main oracle price
-     * and pivot oracle price was succesfull
+     * and pivot oracle price was successfull
      * e.g. vToken decimals is 8 then price is returned as 10**18 * 10**(18-8) = 10**28 decimals
      */
     function _getMainOraclePrice(
@@ -285,7 +285,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @param vToken vToken address
      * @return price USD price in 18 decimals
      * @return pivotValidated Boolean representing if the validation of fallback oracle price
-     * and pivot oracle price was succesfull
+     * and pivot oracle price was successfull
      */
     function _getFallbackOraclePrice(address vToken, uint256 pivotPrice) internal view returns (uint256, bool) {
         (address fallbackOracle, bool fallbackEnabled) = getOracle(vToken, OracleRole.FALLBACK);

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -71,14 +71,14 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
     }
 
     /**
-     * @notice Pause protocol
+     * @notice Pause oracle
      */
     function pause() external onlyOwner {
         _pause();
     }
 
     /**
-     * @notice Unpause protocol
+     * @notice Unpause oracle
      */
     function unpause() external onlyOwner {
         _unpause();

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -200,8 +200,13 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
         }
 
         // Compare main price and pivot price, return main price and if validation was succesfull
-        // note: In case pivot oracle is not available and main price is available, validation is succesfull and main oracle price is returned.
-        (uint256 mainPrice, bool validatedPivotMain) = _getMainOraclePrice(vToken, pivotPrice, pivotOracleEnabled && pivotOracle != address(0));
+        // note: In case pivot oracle is not available and main price is available,
+        // validation is succesfull and main oracle price is returned.
+        (uint256 mainPrice, bool validatedPivotMain) = _getMainOraclePrice(
+            vToken,
+            pivotPrice,
+            pivotOracleEnabled && pivotOracle != address(0)
+        );
         if (mainPrice != INVALID_PRICE && validatedPivotMain) return mainPrice;
 
         // Compare fallback and pivot if main oracle comparision fails with pivot
@@ -234,7 +239,11 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * and pivot oracle price was succesfull
      * e.g. vToken decimals is 8 then price is returned as 10**18 * 10**(18-8) = 10**28 decimals
      */
-    function _getMainOraclePrice(address vToken, uint256 pivotPrice, bool pivotEnabled) internal view returns (uint256, bool) {
+    function _getMainOraclePrice(
+        address vToken,
+        uint256 pivotPrice,
+        bool pivotEnabled
+    ) internal view returns (uint256, bool) {
         (address mainOracle, bool mainOracleEnabled) = getOracle(vToken, OracleRole.MAIN);
         if (mainOracleEnabled && mainOracle != address(0)) {
             try OracleInterface(mainOracle).getUnderlyingPrice(vToken) returns (uint256 mainOraclePrice) {
@@ -244,8 +253,13 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
                 if (pivotPrice == INVALID_PRICE) {
                     return (mainOraclePrice, false);
                 }
-                return (mainOraclePrice, boundValidator.validatePriceWithAnchorPrice(vToken, mainOraclePrice, pivotPrice));
-            } catch { return (INVALID_PRICE, false); }
+                return (
+                    mainOraclePrice,
+                    boundValidator.validatePriceWithAnchorPrice(vToken, mainOraclePrice, pivotPrice)
+                );
+            } catch {
+                return (INVALID_PRICE, false);
+            }
         }
 
         return (INVALID_PRICE, false);
@@ -258,18 +272,20 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @return pivotValidated Boolean representing if the validation of fallback oracle price
      * and pivot oracle price was succesfull
      */
-    function _getFallbackOraclePrice(
-        address vToken,
-        uint256 pivotPrice
-    ) internal view returns (uint256, bool) {
+    function _getFallbackOraclePrice(address vToken, uint256 pivotPrice) internal view returns (uint256, bool) {
         (address fallbackOracle, bool fallbackEnabled) = getOracle(vToken, OracleRole.FALLBACK);
         if (fallbackEnabled && fallbackOracle != address(0)) {
             try OracleInterface(fallbackOracle).getUnderlyingPrice(vToken) returns (uint256 fallbackOraclePrice) {
                 if (pivotPrice == INVALID_PRICE) {
                     return (fallbackOraclePrice, false);
                 }
-                return (fallbackOraclePrice, boundValidator.validatePriceWithAnchorPrice(vToken, fallbackOraclePrice, pivotPrice));
-            } catch { return (INVALID_PRICE, false); }
+                return (
+                    fallbackOraclePrice,
+                    boundValidator.validatePriceWithAnchorPrice(vToken, fallbackOraclePrice, pivotPrice)
+                );
+            } catch {
+                return (INVALID_PRICE, false);
+            }
         }
 
         return (INVALID_PRICE, false);

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -76,6 +76,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
         vBnb = vBnbAddress;
         _disableInitializers();
     }
+
     /**
      * @notice Initializes the contract admin and sets the BoundValidator contract address
      * @param _boundValidator Address of the bound validator contract

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -217,7 +217,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * - check price from main oracle against pivot oracle
      * - check price from fallback oracle against pivot oracle or main oracle if fails
      * @param vToken vToken address
-     * @return price USD price in scaled decimal places, In case pivot oracle is not available 
+     * @return price USD price in scaled decimal places, In case pivot oracle is not available
      * but main price is available and validation is successful, main oracle price is returned.
      * @custom:error paused error thrown when resilent oracle is paused
      * @custom:error Invalid resilient oracle price error thrown if fetched prices from oracle is invalid
@@ -236,7 +236,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
 
         // Compare main price and pivot price, return main price and if validation was successful
         // note: In case pivot oracle is not available but main price is available and
-        // validation is successful, main oracle price is returned.
+        // validation is successful, the main oracle price is returned.
         (uint256 mainPrice, bool validatedPivotMain) = _getMainOraclePrice(
             vToken,
             pivotPrice,
@@ -273,7 +273,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @return pivotValidated Boolean representing if the validation of main oracle price
      * and pivot oracle price was successful
      * @custom:error Invalid price error thrown if main oracle fails to fetch price of underlying asset
-     * @custom:error Invalid price error thrown if main oracle is not enabled or main oracle 
+     * @custom:error Invalid price error thrown if main oracle is not enabled or main oracle
      * address is zero
      */
     function _getMainOraclePrice(
@@ -309,7 +309,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @return pivotValidated Boolean representing if the validation of fallback oracle price
      * and pivot oracle price was successfull
      * @custom:error Invalid price error thrown if fallback oracle fails to fetch price of underlying asset
-     * @custom:error Invalid price error thrown if fallback oracle is not enabled or fallback oracle 
+     * @custom:error Invalid price error thrown if fallback oracle is not enabled or fallback oracle
      * address is zero
      */
     function _getFallbackOraclePrice(address vToken, uint256 pivotPrice) internal view returns (uint256, bool) {

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -82,7 +82,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
      * @param _boundValidator Address of the bound validator contract
      */
     function initialize(BoundValidatorInterface _boundValidator) public initializer {
-        require(address(_boundValidator) != address(0), "invaliud bound validator address");
+        require(address(_boundValidator) != address(0), "invalid bound validator address");
         boundValidator = _boundValidator;
 
         __Ownable_init();

--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -135,7 +135,7 @@ contract ResilientOracle is OwnableUpgradeable, PausableUpgradeable, ResilientOr
     }
 
     /**
-     * @notice Set single token configs, vToken MUST HAVE NOT be added before, and main oracle MUST NOT be zero address
+     * @notice Set/reset single token configs and main oracle MUST NOT be zero address
      * @param tokenConfig token config struct
      */
     function setTokenConfig(

--- a/contracts/oracles/BinanceOracle.sol
+++ b/contracts/oracles/BinanceOracle.sol
@@ -9,6 +9,19 @@ import "../interfaces/BEP20Interface.sol";
 contract BinanceOracle is Initializable {
     FeedRegistryInterface public feedRegistry;
 
+    /// @notice vBNB address
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable vBnb;
+
+    /// @notice Constructor for the implementation contract. Sets immutable variables.
+    /// @param vBnbAddress The address of the VBNB
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address vBnbAddress) {
+        require(vBnbAddress != address(0), "can't be zero address");
+        vBnb = vBnbAddress;
+        _disableInitializers();
+    }
+
     /**
      * @notice Sets the contracts required to fetch price
      * @param feed Address of binance oracle feed registry.
@@ -23,9 +36,18 @@ contract BinanceOracle is Initializable {
      * @return price in USD
      */
     function getUnderlyingPrice(VBep20Interface vToken) public view returns (uint256) {
-        BEP20Interface underlyingToken = BEP20Interface(vToken.underlying());
+        string memory symbol;
+        uint256 decimals;
 
-        string memory symbol = underlyingToken.symbol();
+        // VBNB token doesn't have `underlying` method
+        if (address(vToken) == vBnb) {
+            symbol = "BNB";
+            decimals = 18;
+        } else {
+            BEP20Interface underlyingToken = BEP20Interface(vToken.underlying());
+            symbol = underlyingToken.symbol();
+            decimals = underlyingToken.decimals();
+        }
 
         if (keccak256(bytes(symbol)) == keccak256(bytes("WBNB"))) {
             symbol = "BNB";
@@ -34,6 +56,6 @@ contract BinanceOracle is Initializable {
         (, int256 answer, , , ) = feedRegistry.latestRoundDataByName(symbol, "USD");
 
         uint256 decimalDelta = feedRegistry.decimalsByName(symbol, "USD");
-        return (uint256(answer) * (10 ** (18 - decimalDelta))) * (10 ** (18 - underlyingToken.decimals()));
+        return (uint256(answer) * (10 ** (18 - decimalDelta))) * (10 ** (18 - decimals));
     }
 }

--- a/contracts/oracles/BoundValidator.sol
+++ b/contracts/oracles/BoundValidator.sol
@@ -53,6 +53,8 @@ contract BoundValidator is OwnableUpgradeable, BoundValidatorInterface {
     /**
      * @notice Add multiple validation configs at the same time
      * @param configs config array
+     * @custom:access Only Governance
+     * @custom:error Zero length error thrown, if length of the array in parameter is 0
      */
     function setValidateConfigs(ValidateConfig[] memory configs) external virtual onlyOwner {
         require(configs.length > 0, "invalid validate config length");
@@ -64,6 +66,11 @@ contract BoundValidator is OwnableUpgradeable, BoundValidatorInterface {
     /**
      * @notice Add single validation config
      * @param config config struct
+     * @custom:access Only Governance
+     * @custom:error Zero address error thrown if asset address is zero
+     * @custom:error Range error thrown if bound ratio is not positive
+     * @custom:error Range error thrown if lower bound is greater than upper bound
+     * @custom:event Emits ValidateConfigAdded if succesfully config are set
      */
     function setValidateConfig(ValidateConfig memory config) public virtual onlyOwner {
         require(config.asset != address(0), "asset can't be zero address");
@@ -77,6 +84,8 @@ contract BoundValidator is OwnableUpgradeable, BoundValidatorInterface {
      * @notice Test reported asset price against anchor price
      * @param vToken vToken address
      * @param reporterPrice the price to be tested
+     * @custom:error Missing error thrown if asset config is not set
+     * @custom:error Price error thrwon if anchor price is not valid
      */
     function validatePriceWithAnchorPrice(
         address vToken,

--- a/contracts/oracles/BoundValidator.sol
+++ b/contracts/oracles/BoundValidator.sol
@@ -24,8 +24,24 @@ contract BoundValidator is OwnableUpgradeable, BoundValidatorInterface {
     /// @notice validation configs by asset
     mapping(address => ValidateConfig) public validateConfigs;
 
+    /// @notice vBNB address
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable vBnb;
+
+    /// @notice Set this as asset address for BNB. This is the underlying for vBNB
+    address public constant BNB_ADDR = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
+
     /// @notice Emit this event when new validate configs are added
     event ValidateConfigAdded(address indexed asset, uint256 indexed upperBound, uint256 indexed lowerBound);
+
+    /// @notice Constructor for the implementation contract. Sets immutable variables.
+    /// @param vBnbAddress The address of the VBNB
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address vBnbAddress) {
+        require(vBnbAddress != address(0), "can't be zero address");
+        vBnb = vBnbAddress;
+        _disableInitializers();
+    }
 
     /**
      * @notice Initializes the owner of the contract
@@ -67,7 +83,7 @@ contract BoundValidator is OwnableUpgradeable, BoundValidatorInterface {
         uint256 reporterPrice,
         uint256 anchorPrice
     ) public view virtual override returns (bool) {
-        address asset = VBep20Interface(vToken).underlying();
+        address asset = vToken == vBnb ? BNB_ADDR : VBep20Interface(vToken).underlying();
 
         require(validateConfigs[asset].upperBoundRatio != 0, "validation config not exist");
         require(anchorPrice != 0, "anchor price is not valid");

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -131,7 +131,7 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
         (, int256 answer, , uint256 updatedAt, ) = feed.latestRoundData();
         require(answer > 0, "chainlink price must be positive");
 
-        require(block.timestamp > updatedAt, "updatedAt exceeds block time");
+        require(block.timestamp >= updatedAt, "updatedAt exceeds block time");
         uint256 deltaTime = block.timestamp - updatedAt;
         require(deltaTime <= maxStalePeriod, "chainlink price expired");
 

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -99,8 +99,9 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
             decimals = VBep20Interface(token).decimals();
         }
 
-        if (prices[token] != 0) {
-            price = prices[token];
+        uint256 tokenPrice = prices[token];
+        if (tokenPrice != 0) {
+            price = tokenPrice;
         } else {
             price = _getChainlinkPrice(token);
         }
@@ -118,7 +119,7 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
     function _getChainlinkPrice(
         address asset
     ) internal view notNullAddress(tokenConfigs[asset].asset) returns (uint256) {
-        TokenConfig storage tokenConfig = tokenConfigs[asset];
+        TokenConfig memory tokenConfig = tokenConfigs[asset];
         AggregatorV2V3Interface feed = AggregatorV2V3Interface(tokenConfig.feed);
 
         // note: maxStalePeriod cannot be 0

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -115,6 +115,11 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
      * @dev The decimals of feeds are considered
      * @param asset underlying asset address
      * @return price in USD, with 18 decimals
+     * @custom:error NotNullAddress error thrown if asset address is zero
+     * @custom:error Price error if chain link price of asset is not greater than zero
+     * @custom:error Timing error if current timestamp is less than last updated at timestamp
+     * @custom:error Timing error if time difference between current time and last update time
+     * is greater than maxStalePeriod
      */
     function _getChainlinkPrice(
         address asset
@@ -142,6 +147,9 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
      * @notice Set the forced prices of the underlying token of input vToken
      * @param vToken vToken address
      * @param underlyingPriceMantissa price in 18 decimals
+     * @custom:access Only Governance
+     * @custom:error NotNullAddress thrown if address of vToken is zero
+     * @custom:event Emits PricePosted event on succesfully setup of underlying price
      */
     function setUnderlyingPrice(
         VBep20Interface vToken,
@@ -156,6 +164,8 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
      * @notice Set the forced prices of the input token
      * @param asset asset address
      * @param price price in 18 decimals
+     * @custom:access Only GOvernance
+     * @custom:event Emits PricePosted event on succesfully setup of underlying price
      */
     function setDirectPrice(address asset, uint256 price) external onlyOwner {
         emit PricePosted(asset, prices[asset], price, price);
@@ -165,6 +175,8 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
     /**
      * @notice Add multiple token configs at the same time
      * @param tokenConfigs_ config array
+     * @custom:access Only Governance
+     * @custom:error Zero length error thrown, if length of the array in parameter is 0
      */
     function setTokenConfigs(TokenConfig[] memory tokenConfigs_) external onlyOwner {
         require(tokenConfigs_.length > 0, "length can't be 0");
@@ -175,7 +187,12 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
 
     /**
      * @notice Add single token config, vToken & feed cannot be zero address, and maxStalePeriod must be positive
-     * @param tokenConfig token config struct
+     * @param tokenConfig token config struct\
+     * @custom:access Only Governance
+     * @custom:error NotNullAddress error thrown if asset address is zero
+     * @custom:error NotNullAddress error thrown if token feed address is zero
+     * @custom:error Range error if maxStale period of token is not greater than zero
+     * @custom:event Emits TokenConfigAdded event on succesfully setting up token config
      */
     function setTokenConfig(
         TokenConfig memory tokenConfig

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -142,7 +142,10 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
      * @param vToken vToken address
      * @param underlyingPriceMantissa price in 18 decimals
      */
-    function setUnderlyingPrice(VBep20Interface vToken, uint256 underlyingPriceMantissa) external onlyOwner {
+    function setUnderlyingPrice(
+        VBep20Interface vToken,
+        uint256 underlyingPriceMantissa
+    ) external notNullAddress(address(vToken)) onlyOwner {
         address asset = address(vToken) == vBnb ? BNB_ADDR : address(vToken.underlying());
         emit PricePosted(asset, prices[asset], underlyingPriceMantissa, underlyingPriceMantissa);
         prices[asset] = underlyingPriceMantissa;

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -115,7 +115,9 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
      * @param asset underlying asset address
      * @return price in USD, with 18 decimals
      */
-    function _getChainlinkPrice(address asset) internal view notNullAddress(tokenConfigs[asset].asset) returns (uint256) {
+    function _getChainlinkPrice(
+        address asset
+    ) internal view notNullAddress(tokenConfigs[asset].asset) returns (uint256) {
         TokenConfig storage tokenConfig = tokenConfigs[asset];
         AggregatorV2V3Interface feed = AggregatorV2V3Interface(tokenConfig.feed);
 

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -187,7 +187,7 @@ contract ChainlinkOracle is OwnableUpgradeable, OracleInterface {
 
     /**
      * @notice Add single token config, vToken & feed cannot be zero address, and maxStalePeriod must be positive
-     * @param tokenConfig token config struct\
+     * @param tokenConfig token config struct
      * @custom:access Only Governance
      * @custom:error NotNullAddress error thrown if asset address is zero
      * @custom:error NotNullAddress error thrown if token feed address is zero

--- a/contracts/oracles/PythOracle.sol
+++ b/contracts/oracles/PythOracle.sol
@@ -144,13 +144,9 @@ contract PythOracle is OwnableUpgradeable, OracleInterface {
         // the price returned from Pyth is price ** 10^expo, which is the real dollar price of the assets
         // we need to multiply it by 1e18 to make the price 18 decimals
         if (priceInfo.expo > 0) {
-            return
-                price.mul(EXP_SCALE).mul(10 ** int256(priceInfo.expo).toUint256()) *
-                (10 ** (18 - decimals));
+            return price.mul(EXP_SCALE).mul(10 ** int256(priceInfo.expo).toUint256()) * (10 ** (18 - decimals));
         } else {
-            return
-                price.mul(EXP_SCALE).div(10 ** int256(-priceInfo.expo).toUint256()) *
-                (10 ** (18 - decimals));
+            return price.mul(EXP_SCALE).div(10 ** int256(-priceInfo.expo).toUint256()) * (10 ** (18 - decimals));
         }
     }
 }

--- a/contracts/oracles/PythOracle.sol
+++ b/contracts/oracles/PythOracle.sol
@@ -78,6 +78,8 @@ contract PythOracle is OwnableUpgradeable, OracleInterface {
     /**
      * @notice Batch set token configs
      * @param tokenConfigs_ token config array
+     * @custom:access Only Governance
+     * @custom:error Zero length error thrown, if length of the array in parameter is 0
      */
     function setTokenConfigs(TokenConfig[] memory tokenConfigs_) external onlyOwner {
         require(tokenConfigs_.length != 0, "length can't be 0");
@@ -89,6 +91,9 @@ contract PythOracle is OwnableUpgradeable, OracleInterface {
     /**
      * @notice Set single token config, `maxStalePeriod` cannot be 0 and `vToken` can be zero address
      * @param tokenConfig token config struct
+     * @custom:access Only Governance
+     * @custom:error Range error thrown if max stale period is zero
+     * @custom:error NotNullAddress error thrown if asset address is zero
      */
     function setTokenConfig(TokenConfig memory tokenConfig) public onlyOwner notNullAddress(tokenConfig.asset) {
         require(tokenConfig.maxStalePeriod != 0, "max stale period cannot be 0");
@@ -99,6 +104,9 @@ contract PythOracle is OwnableUpgradeable, OracleInterface {
     /**
      * @notice set the underlying pyth oracle contract address
      * @param underlyingPythOracle_ pyth oracle contract address
+     * @custom:access Only Governance
+     * @custom:error NotNullAddress error thrown if underlyingPythOracle_ address is zero
+     * @custom:event Emits PythOracleSet event with address of Pyth oracle.
      */
     function setUnderlyingPythOracle(
         IPyth underlyingPythOracle_
@@ -112,6 +120,9 @@ contract PythOracle is OwnableUpgradeable, OracleInterface {
      * get price from Pyth contract, the prices of which are updated externally
      * @param vToken vToken address
      * @return price in 10 decimals
+     * @custom:error Zero address error thrown if underlyingPythOracle address is zero
+     * @custom:error Zero address error thrown if asset address is zero
+     * @custom:error Range error thrown if price of pythoracle is not greater than zero
      */
     function getUnderlyingPrice(address vToken) public view override returns (uint256) {
         require(address(underlyingPythOracle) != address(0), "Pyth oracle is zero address");

--- a/contracts/oracles/TwapOracle.sol
+++ b/contracts/oracles/TwapOracle.sol
@@ -116,6 +116,11 @@ contract TwapOracle is OwnableUpgradeable, TwapInterface {
     ) public onlyOwner notNullAddress(config.asset) notNullAddress(config.pancakePool) {
         require(config.anchorPeriod > 0, "anchor period must be positive");
         require(config.baseUnit > 0, "base unit must be positive");
+        require(
+            config.baseUnit == 10 ** BEP20Interface(config.asset).decimals(),
+            "base unit decimals must be same as asset decimals"
+        );
+
         uint256 cumulativePrice = currentCumulativePrice(config);
 
         // Initialize observation data

--- a/contracts/oracles/TwapOracle.sol
+++ b/contracts/oracles/TwapOracle.sol
@@ -25,7 +25,8 @@ struct TokenConfig {
     /// @notice A flag identifies whether the pancake pair is reversed
     /// e.g. XVS-WBNB is not reversed, while WBNB-XVS is.
     bool isReversedPool;
-    /// @notice **twap** update period in second, which is the minimum time in seconds required to update **twap** window
+    /// @notice **twap** update period in second, which is the minimum time in seconds
+    /// required to update **twap** window
     uint256 anchorPeriod;
 }
 
@@ -113,12 +114,12 @@ contract TwapOracle is OwnableUpgradeable, TwapInterface {
      * @param config token config struct
      * @custom:access Only Governance
      * @custom:error Range error thrown if anchor period is not greater than zero
-     * @custom:error Range error thrown if base unit is not greater than zero 
+     * @custom:error Range error thrown if base unit is not greater than zero
      * @custom:error Value error thrown if base unit decimals not same as asset decimals
      * @custom:error NotNullAddress if address of asset is zero
      * @custom:error NotNullAddress if pancake swap pool address is zero
-     * @custom:event Emits TokenConfigAdded event if new token configs are added with asset address,
-     * pancakepool address, anchor period address
+     * @custom:event Emits TokenConfigAdded event if new token config are added with
+     * asset address, pancakepool address, anchor period address
      */
     function setTokenConfig(
         TokenConfig memory config

--- a/test/BinanceOracle.ts
+++ b/test/BinanceOracle.ts
@@ -21,11 +21,13 @@ describe("Binance Oracle unit tests", function () {
     this.mockBinanceFeedRegistry = <MockBinanceFeedRegistry>await upgrades.deployProxy(MockBinanceFeedRegistry, []);
 
     const BinanceOracle = await ethers.getContractFactory("BinanceOracle", admin);
-    console.log(this.vBnb)
-    this.binanceOracle = <BinanceOracle>(
-      await upgrades.deployProxy(BinanceOracle, [this.mockBinanceFeedRegistry.address], {
+    console.log(this.vBnb);
+    this.binanceOracle = <BinanceOracle>await upgrades.deployProxy(
+      BinanceOracle,
+      [this.mockBinanceFeedRegistry.address],
+      {
         constructorArgs: [this.vBnb],
-      })
+      },
     );
   });
 
@@ -41,10 +43,10 @@ describe("Binance Oracle unit tests", function () {
 
   it("fetch price", async function () {
     expect(await this.binanceOracle.getUnderlyingPrice(this.vEth.address)).to.be.equal("1333789241690000000000");
-    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");  
+    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");
   });
 
   it("fetch BNB price", async function () {
-    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");  
+    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");
   });
 });

--- a/test/BinanceOracle.ts
+++ b/test/BinanceOracle.ts
@@ -11,16 +11,21 @@ describe("Binance Oracle unit tests", function () {
     const admin = signers[0];
     this.signers = signers;
     this.admin = admin;
+    this.vBnb = signers[5].address;
 
     this.vEth = await makeVToken(admin, { name: "vETH", symbol: "vETH" }, { name: "Ethereum", symbol: "ETH" });
     this.ethPrice = "133378924169"; //$1333.78924169
+    this.bnbPrice = "24598000000"; //$245.98
 
     const MockBinanceFeedRegistry = await ethers.getContractFactory("MockBinanceFeedRegistry", admin);
     this.mockBinanceFeedRegistry = <MockBinanceFeedRegistry>await upgrades.deployProxy(MockBinanceFeedRegistry, []);
 
     const BinanceOracle = await ethers.getContractFactory("BinanceOracle", admin);
+    console.log(this.vBnb)
     this.binanceOracle = <BinanceOracle>(
-      await upgrades.deployProxy(BinanceOracle, [this.mockBinanceFeedRegistry.address])
+      await upgrades.deployProxy(BinanceOracle, [this.mockBinanceFeedRegistry.address], {
+        constructorArgs: [this.vBnb],
+      })
     );
   });
 
@@ -29,7 +34,17 @@ describe("Binance Oracle unit tests", function () {
     expect(await this.mockBinanceFeedRegistry.assetPrices("ETH")).to.be.equal(this.ethPrice);
   });
 
+  it("set BNB price", async function () {
+    this.mockBinanceFeedRegistry.setAssetPrice("BNB", this.bnbPrice);
+    expect(await this.mockBinanceFeedRegistry.assetPrices("BNB")).to.be.equal(this.bnbPrice);
+  });
+
   it("fetch price", async function () {
     expect(await this.binanceOracle.getUnderlyingPrice(this.vEth.address)).to.be.equal("1333789241690000000000");
+    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");  
+  });
+
+  it("fetch BNB price", async function () {
+    expect(await this.binanceOracle.getUnderlyingPrice(this.vBnb)).to.be.equal("245980000000000000000");  
   });
 });

--- a/test/BoundValidator.ts
+++ b/test/BoundValidator.ts
@@ -12,11 +12,9 @@ const EXP_SCALE = BigNumber.from(10).pow(18);
 const getBoundValidator = async (account: SignerWithAddress, vBnb: string) => {
   const BoundValidator = await ethers.getContractFactory("BoundValidator", account);
 
-  return <BoundValidator>(
-    await upgrades.deployProxy(BoundValidator, [], {
-      constructorArgs: [vBnb],
-    })
-  );;
+  return <BoundValidator>await upgrades.deployProxy(BoundValidator, [], {
+    constructorArgs: [vBnb],
+  });
 };
 
 describe("bound validator", function () {
@@ -147,11 +145,7 @@ describe("bound validator", function () {
         "anchor price is not valid",
       );
 
-      let validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
-        vBnb,
-        EXP_SCALE,
-        anchorPrice,
-      );
+      let validateResult = await this.boundValidator.validatePriceWithAnchorPrice(vBnb, EXP_SCALE, anchorPrice);
       expect(validateResult).to.equal(true);
       validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
         vBnb,

--- a/test/ChainlinkOracle.ts
+++ b/test/ChainlinkOracle.ts
@@ -44,7 +44,7 @@ describe("Oracle unit tests", function () {
 
     const ChainlinkOracle = await ethers.getContractFactory("ChainlinkOracle", admin);
     const instance = <ChainlinkOracle>await upgrades.deployProxy(ChainlinkOracle, [], {
-      constructorArgs: [this.vBnb.address]
+      constructorArgs: [this.vBnb.address],
     });
     this.chainlinkOracle = instance;
     return instance;

--- a/test/ChainlinkOracle.ts
+++ b/test/ChainlinkOracle.ts
@@ -18,8 +18,9 @@ describe("Oracle unit tests", function () {
     this.signers = signers;
     this.admin = admin;
 
+    this.bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
     this.vToken = await makeVToken(admin, { name: "vToken", symbol: "vToken" }, { name: "Token", symbol: "Token" });
-    this.vBnb = await makeVToken(admin, { name: "vBNB", symbol: "vBNB" }, { name: "BNB", symbol: "BNB" });
+    this.vBnb = signers[5]; // Not your standard vToken
     this.vai = await makeVToken(admin, { name: "VAI", symbol: "VAI" });
     this.xvs = await makeVToken(admin, { name: "XVS", symbol: "XVS" });
     this.vExampleSet = await makeVToken(admin, { name: "vExampleSet", symbol: "vExampleSet" });
@@ -42,7 +43,9 @@ describe("Oracle unit tests", function () {
     this.daiFeed = await makeChainlinkOracle(admin, 8, 100000000);
 
     const ChainlinkOracle = await ethers.getContractFactory("ChainlinkOracle", admin);
-    const instance = <ChainlinkOracle>await upgrades.deployProxy(ChainlinkOracle, []);
+    const instance = <ChainlinkOracle>await upgrades.deployProxy(ChainlinkOracle, [], {
+      constructorArgs: [this.vBnb.address]
+    });
     this.chainlinkOracle = instance;
     return instance;
   });
@@ -58,7 +61,7 @@ describe("Oracle unit tests", function () {
     it("only admin may set token config", async function () {
       await expect(
         this.chainlinkOracle.connect(this.signers[2]).setTokenConfig({
-          asset: await this.vBnb.underlying(),
+          asset: this.bnbAddr,
           feed: this.bnbFeed.address,
           maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
         }),
@@ -68,7 +71,7 @@ describe("Oracle unit tests", function () {
     it("cannot set feed to zero address", async function () {
       await expect(
         this.chainlinkOracle.setTokenConfig({
-          asset: await this.vBnb.underlying(),
+          asset: this.bnbAddr,
           feed: addr0000,
           maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
         }),
@@ -77,11 +80,11 @@ describe("Oracle unit tests", function () {
 
     it("sets a token config", async function () {
       await this.chainlinkOracle.setTokenConfig({
-        asset: await this.vBnb.underlying(),
+        asset: this.bnbAddr,
         feed: this.bnbFeed.address,
         maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
       });
-      const tokenConfig = await this.chainlinkOracle.tokenConfigs(await this.vBnb.underlying());
+      const tokenConfig = await this.chainlinkOracle.tokenConfigs(this.bnbAddr);
       expect(tokenConfig.feed).to.be.equal(this.bnbFeed.address);
     });
   });
@@ -91,7 +94,7 @@ describe("Oracle unit tests", function () {
       await expect(
         this.chainlinkOracle.connect(this.signers[2]).setTokenConfigs([
           {
-            asset: await this.vBnb.underlying(),
+            asset: this.bnbAddr,
             feed: this.bnbFeed.address,
             maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
           },
@@ -103,7 +106,7 @@ describe("Oracle unit tests", function () {
       await expect(
         this.chainlinkOracle.setTokenConfigs([
           {
-            asset: await this.vBnb.underlying(),
+            asset: this.bnbAddr,
             feed: addr0000,
             maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
           },
@@ -127,7 +130,7 @@ describe("Oracle unit tests", function () {
     it("set multiple feeds", async function () {
       await this.chainlinkOracle.setTokenConfigs([
         {
-          asset: await this.vBnb.underlying(),
+          asset: this.bnbAddr,
           feed: this.bnbFeed.address,
           maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD).mul(2),
         },
@@ -138,7 +141,7 @@ describe("Oracle unit tests", function () {
         },
       ]);
 
-      const [, newBnbFeed, newBnbStalePeriod] = await this.chainlinkOracle.tokenConfigs(await this.vBnb.underlying());
+      const [, newBnbFeed, newBnbStalePeriod] = await this.chainlinkOracle.tokenConfigs(this.bnbAddr);
       const [, newUsdtFeed, newUsdtStalePeriod] = await this.chainlinkOracle.tokenConfigs(
         await this.vUsdt.underlying(),
       );
@@ -153,7 +156,7 @@ describe("Oracle unit tests", function () {
   describe("getUnderlyingPrice", () => {
     beforeEach(async function () {
       await this.chainlinkOracle.setTokenConfig({
-        asset: await this.vBnb.underlying(),
+        asset: this.bnbAddr,
         feed: this.bnbFeed.address,
         maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
       });
@@ -245,7 +248,7 @@ describe("Oracle unit tests", function () {
   describe("stale price validation", () => {
     beforeEach(async function () {
       await this.chainlinkOracle.setTokenConfig({
-        asset: await this.vBnb.underlying(),
+        asset: this.bnbAddr,
         feed: this.bnbFeed.address,
         maxStalePeriod: BigNumber.from(MAX_STALE_PERIOD),
       });
@@ -254,7 +257,7 @@ describe("Oracle unit tests", function () {
     it("stale price period cannot be 0", async function () {
       await expect(
         this.chainlinkOracle.setTokenConfig({
-          asset: await this.vBnb.underlying(),
+          asset: this.bnbAddr,
           feed: this.bnbFeed.address,
           maxStalePeriod: 0,
         }),
@@ -263,13 +266,13 @@ describe("Oracle unit tests", function () {
 
     it("modify stale price period will emit an event", async function () {
       const result = await this.chainlinkOracle.setTokenConfig({
-        asset: await this.vBnb.underlying(),
+        asset: this.bnbAddr,
         feed: this.bnbFeed.address,
         maxStalePeriod: MAX_STALE_PERIOD,
       });
       await expect(result)
         .to.emit(this.chainlinkOracle, "TokenConfigAdded")
-        .withArgs(await this.vBnb.underlying(), this.bnbFeed.address, MAX_STALE_PERIOD);
+        .withArgs(this.bnbAddr, this.bnbFeed.address, MAX_STALE_PERIOD);
     });
 
     it("revert when price stale", async function () {

--- a/test/PivotPythOracle.ts
+++ b/test/PivotPythOracle.ts
@@ -11,19 +11,23 @@ import { getTime, increaseTime } from "./utils/time";
 
 const EXP_SCALE = BigNumber.from(10).pow(18);
 
-const getPythOracle = async (account: SignerWithAddress) => {
+const getPythOracle = async (account: SignerWithAddress, vBnb: string) => {
   const actualOracleArtifact = await artifacts.readArtifact("MockPyth");
   const actualOracle = await waffle.deployContract(account, actualOracleArtifact, [0, 0]);
   await actualOracle.deployed();
 
   const PythOracle = await ethers.getContractFactory("PythOracle", account);
-  const instance = <PythOracle>await upgrades.deployProxy(PythOracle, [actualOracle.address]);
+  const instance = <PythOracle>await upgrades.deployProxy(PythOracle, [actualOracle.address], {
+    constructorArgs: [vBnb],
+  });
   return instance;
 };
 
-const getBoundValidator = async (account: SignerWithAddress) => {
+const getBoundValidator = async (account: SignerWithAddress, vBnb: string) => {
   const BoundValidator = await ethers.getContractFactory("BoundValidator", account);
-  const instance = <BoundValidator>await upgrades.deployProxy(BoundValidator, []);
+  const instance = <BoundValidator>await upgrades.deployProxy(BoundValidator, [], {
+    constructorArgs: [vBnb],
+  });
   return instance;
 };
 
@@ -31,10 +35,11 @@ describe("Oracle plugin frame unit tests", function () {
   beforeEach(async function () {
     const signers: SignerWithAddress[] = await ethers.getSigners();
     const admin = signers[0];
+    this.vBnb = signers[5].address;
     this.signers = signers;
     this.admin = admin;
-    this.pythOracle = await getPythOracle(admin);
-    this.boundValidator = await getBoundValidator(admin);
+    this.pythOracle = await getPythOracle(admin, this.vBnb);
+    this.boundValidator = await getBoundValidator(admin, this.vBnb);
   });
 
   describe("constructor", function () {
@@ -336,5 +341,67 @@ describe("Oracle plugin frame unit tests", function () {
       );
       expect(validateResult).to.equal(false);
     });
+    it("validate BNB price", async function () {
+        const bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        const validationConfig = {
+          asset: bnbAddr,
+          upperBoundRatio: EXP_SCALE.mul(12).div(10),
+          lowerBoundRatio: EXP_SCALE.mul(8).div(10),
+        };
+  
+        // set price
+        await this.pythOracle.setTokenConfig({
+          asset: bnbAddr,
+          pythId: getBytes32String(3),
+          maxStalePeriod: 111,
+        });
+        const feed = {
+          id: getBytes32String(3),
+          price: {
+            price: BigNumber.from(10).pow(6),
+            conf: 10,
+            expo: BigNumber.from(-6),
+            publishTime: await getTime(),
+          },
+          emaPrice: {
+            price: 0,
+            conf: 0,
+            expo: 0,
+            publishTime: 0,
+          },
+        };
+  
+        const underlyingPythAddress = await this.pythOracle.underlyingPythOracle();
+        const UnderlyingPythFactory = await ethers.getContractFactory("MockPyth");
+        const underlyingPyth = UnderlyingPythFactory.attach(underlyingPythAddress);
+        const underlyingPythOracle = <MockPyth>underlyingPyth;
+        await underlyingPythOracle.updatePriceFeedsHarness([feed]);
+  
+        // sanity check
+        await expect(this.boundValidator.validatePriceWithAnchorPrice(this.vBnb, 100, 0)).to.be.revertedWith(
+          "validation config not exist",
+        );
+  
+        await this.boundValidator.setValidateConfigs([validationConfig]);
+  
+        let validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+          this.vBnb,
+          EXP_SCALE,
+          await this.pythOracle.getUnderlyingPrice(this.vBnb),
+        );
+        expect(validateResult).to.equal(true);
+        validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+          this.vBnb,
+          EXP_SCALE.mul(100).div(79),
+          await this.pythOracle.getUnderlyingPrice(this.vBnb),
+        );
+        expect(validateResult).to.equal(false);
+        validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+          this.vBnb,
+          EXP_SCALE.mul(100).div(121),
+          await this.pythOracle.getUnderlyingPrice(this.vBnb),
+        );
+        expect(validateResult).to.equal(false);
+      });
   });
 });

--- a/test/PivotPythOracle.ts
+++ b/test/PivotPythOracle.ts
@@ -342,66 +342,66 @@ describe("Oracle plugin frame unit tests", function () {
       expect(validateResult).to.equal(false);
     });
     it("validate BNB price", async function () {
-        const bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
-        const validationConfig = {
-          asset: bnbAddr,
-          upperBoundRatio: EXP_SCALE.mul(12).div(10),
-          lowerBoundRatio: EXP_SCALE.mul(8).div(10),
-        };
-  
-        // set price
-        await this.pythOracle.setTokenConfig({
-          asset: bnbAddr,
-          pythId: getBytes32String(3),
-          maxStalePeriod: 111,
-        });
-        const feed = {
-          id: getBytes32String(3),
-          price: {
-            price: BigNumber.from(10).pow(6),
-            conf: 10,
-            expo: BigNumber.from(-6),
-            publishTime: await getTime(),
-          },
-          emaPrice: {
-            price: 0,
-            conf: 0,
-            expo: 0,
-            publishTime: 0,
-          },
-        };
-  
-        const underlyingPythAddress = await this.pythOracle.underlyingPythOracle();
-        const UnderlyingPythFactory = await ethers.getContractFactory("MockPyth");
-        const underlyingPyth = UnderlyingPythFactory.attach(underlyingPythAddress);
-        const underlyingPythOracle = <MockPyth>underlyingPyth;
-        await underlyingPythOracle.updatePriceFeedsHarness([feed]);
-  
-        // sanity check
-        await expect(this.boundValidator.validatePriceWithAnchorPrice(this.vBnb, 100, 0)).to.be.revertedWith(
-          "validation config not exist",
-        );
-  
-        await this.boundValidator.setValidateConfigs([validationConfig]);
-  
-        let validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
-          this.vBnb,
-          EXP_SCALE,
-          await this.pythOracle.getUnderlyingPrice(this.vBnb),
-        );
-        expect(validateResult).to.equal(true);
-        validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
-          this.vBnb,
-          EXP_SCALE.mul(100).div(79),
-          await this.pythOracle.getUnderlyingPrice(this.vBnb),
-        );
-        expect(validateResult).to.equal(false);
-        validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
-          this.vBnb,
-          EXP_SCALE.mul(100).div(121),
-          await this.pythOracle.getUnderlyingPrice(this.vBnb),
-        );
-        expect(validateResult).to.equal(false);
+      const bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
+      const validationConfig = {
+        asset: bnbAddr,
+        upperBoundRatio: EXP_SCALE.mul(12).div(10),
+        lowerBoundRatio: EXP_SCALE.mul(8).div(10),
+      };
+
+      // set price
+      await this.pythOracle.setTokenConfig({
+        asset: bnbAddr,
+        pythId: getBytes32String(3),
+        maxStalePeriod: 111,
       });
+      const feed = {
+        id: getBytes32String(3),
+        price: {
+          price: BigNumber.from(10).pow(6),
+          conf: 10,
+          expo: BigNumber.from(-6),
+          publishTime: await getTime(),
+        },
+        emaPrice: {
+          price: 0,
+          conf: 0,
+          expo: 0,
+          publishTime: 0,
+        },
+      };
+
+      const underlyingPythAddress = await this.pythOracle.underlyingPythOracle();
+      const UnderlyingPythFactory = await ethers.getContractFactory("MockPyth");
+      const underlyingPyth = UnderlyingPythFactory.attach(underlyingPythAddress);
+      const underlyingPythOracle = <MockPyth>underlyingPyth;
+      await underlyingPythOracle.updatePriceFeedsHarness([feed]);
+
+      // sanity check
+      await expect(this.boundValidator.validatePriceWithAnchorPrice(this.vBnb, 100, 0)).to.be.revertedWith(
+        "validation config not exist",
+      );
+
+      await this.boundValidator.setValidateConfigs([validationConfig]);
+
+      let validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+        this.vBnb,
+        EXP_SCALE,
+        await this.pythOracle.getUnderlyingPrice(this.vBnb),
+      );
+      expect(validateResult).to.equal(true);
+      validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+        this.vBnb,
+        EXP_SCALE.mul(100).div(79),
+        await this.pythOracle.getUnderlyingPrice(this.vBnb),
+      );
+      expect(validateResult).to.equal(false);
+      validateResult = await this.boundValidator.validatePriceWithAnchorPrice(
+        this.vBnb,
+        EXP_SCALE.mul(100).div(121),
+        await this.pythOracle.getUnderlyingPrice(this.vBnb),
+      );
+      expect(validateResult).to.equal(false);
+    });
   });
 });

--- a/test/PivotTwapOracle.ts
+++ b/test/PivotTwapOracle.ts
@@ -40,7 +40,7 @@ describe("Twap Oracle unit tests", function () {
     this.signers = signers;
     this.admin = admin;
     this.vBnb = signers[5]; // Not your usual vToken
-    this.wBnb = await makeToken(admin, "Wrapped BNB", "WBNB");
+    this.wBnb = await makeToken(admin, "Wrapped BNB", "WBNB", 18);
     this.bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
 
     const TwapOracle = await ethers.getContractFactory("TwapOracle", admin);
@@ -91,7 +91,7 @@ describe("Twap Oracle unit tests", function () {
       // setTokenConfigs
       const config = {
         asset: this.wBnb.address,
-        baseUnit: 100,
+        baseUnit: EXP_SCALE,
         pancakePool: addr1111,
         isBnbBased: false,
         isReversedPool: false,
@@ -131,7 +131,7 @@ describe("Twap Oracle unit tests", function () {
       it("vToken can\"t be zero & pool address can't be zero & anchorPeriod can't be 0", async function () {
         const config = {
           asset: addr0000,
-          baseUnit: 0,
+          baseUnit: BigNumber.from(0),
           pancakePool: addr0000,
           isBnbBased: false,
           isReversedPool: false,
@@ -147,7 +147,7 @@ describe("Twap Oracle unit tests", function () {
 
         config.anchorPeriod = 100;
         await expect(this.twapOracle.setTokenConfig(config)).to.be.revertedWith("base unit must be positive");
-        config.baseUnit = 100;
+        config.baseUnit = EXP_SCALE;
 
         // nothing happen
         await this.twapOracle.setTokenConfig(config);
@@ -162,7 +162,7 @@ describe("Twap Oracle unit tests", function () {
 
         const config1 = {
           asset: this.wBnb.address,
-          baseUnit: 100,
+          baseUnit: EXP_SCALE,
           pancakePool: this.simplePair.address,
           isBnbBased: true,
           isReversedPool: false,
@@ -170,7 +170,7 @@ describe("Twap Oracle unit tests", function () {
         };
         const config2 = {
           asset: await vToken.underlying(),
-          baseUnit: 1000,
+          baseUnit: EXP_SCALE,
           pancakePool: this.simplePair.address,
           isBnbBased: false,
           isReversedPool: true,
@@ -185,7 +185,7 @@ describe("Twap Oracle unit tests", function () {
       it("token config added successfully & events check", async function () {
         const config = {
           asset: this.wBnb.address,
-          baseUnit: 100,
+          baseUnit: EXP_SCALE,
           pancakePool: this.simplePair.address,
           isBnbBased: false,
           isReversedPool: false,
@@ -211,7 +211,7 @@ describe("Twap Oracle unit tests", function () {
       it("token config added successfully & data check", async function () {
         const config = {
           asset: this.wBnb.address,
-          baseUnit: 100,
+          baseUnit: EXP_SCALE,
           pancakePool: this.simplePair.address,
           isBnbBased: false,
           isReversedPool: false,
@@ -222,7 +222,7 @@ describe("Twap Oracle unit tests", function () {
         expect(savedConfig.anchorPeriod).to.equal(888);
         expect(savedConfig.asset).to.equal(this.wBnb.address);
         expect(savedConfig.pancakePool).to.equal(this.simplePair.address);
-        expect(savedConfig.baseUnit).to.equal(100);
+        expect(savedConfig.baseUnit).to.equal(EXP_SCALE);
       });
     });
   });

--- a/test/PivotTwapOracle.ts
+++ b/test/PivotTwapOracle.ts
@@ -45,13 +45,13 @@ describe("Twap Oracle unit tests", function () {
 
     const TwapOracle = await ethers.getContractFactory("TwapOracle", admin);
     const twapInstance = <TwapOracle>await upgrades.deployProxy(TwapOracle, [], {
-        constructorArgs: [this.vBnb.address, this.wBnb.address],
+      constructorArgs: [this.vBnb.address, this.wBnb.address],
     });
     this.twapOracle = twapInstance;
 
     const BoundValidator = await ethers.getContractFactory("BoundValidator", admin);
     const boundValidatorInstance = <BoundValidator>await upgrades.deployProxy(BoundValidator, [], {
-        constructorArgs: [this.vBnb.address],
+      constructorArgs: [this.vBnb.address],
     });
     this.boundValidator = boundValidatorInstance;
 

--- a/test/ResilientOracle.ts
+++ b/test/ResilientOracle.ts
@@ -37,11 +37,15 @@ describe("Oracle plugin frame unit tests", function () {
     this.pivotOracle = await getPivotOracle(admin);
     this.fallbackOracle = await getSimpleOracle(admin);
     this.boundValidator = await getBoundValidator(admin);
+    this.vBnb = signers[5].address;
+    this.bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
   });
 
   beforeEach(async function () {
     const ResilientOracle = await ethers.getContractFactory("ResilientOracle", this.admin);
-    const instance = <ResilientOracle>await upgrades.deployProxy(ResilientOracle, [this.boundValidator.address]);
+    const instance = <ResilientOracle>await upgrades.deployProxy(ResilientOracle, [this.boundValidator.address], {
+        constructorArgs: [this.vBnb],
+    });
     this.oracleBasement = instance;
   });
 
@@ -294,6 +298,8 @@ describe("Oracle plugin frame unit tests", function () {
     let asset1;
     let token2;
     let asset2;
+    let token3;
+    let asset3;
 
     const token1FallbackPrice = 2222222;
     const token2FallbackPrice = 3333333;
@@ -307,6 +313,9 @@ describe("Oracle plugin frame unit tests", function () {
       asset2 = await token2.underlying();
       token2 = token2.address;
 
+      token3 = this.vBnb;
+      asset3 = this.bnbAddr;
+
       await this.oracleBasement.setTokenConfigs([
         {
           asset: asset1,
@@ -318,9 +327,15 @@ describe("Oracle plugin frame unit tests", function () {
           oracles: [this.mainOracle.address, this.pivotOracle.address, this.fallbackOracle.address],
           enableFlagsForOracles: [true, true, false],
         },
+        {
+          asset: asset3,
+          oracles: [this.mainOracle.address, this.pivotOracle.address, this.fallbackOracle.address],
+          enableFlagsForOracles: [true, true, false],
+        },
       ]);
       this.fallbackOracle.setPrice(token1, token1FallbackPrice);
       this.fallbackOracle.setPrice(token2, token2FallbackPrice);
+      this.fallbackOracle.setPrice(token3, token2FallbackPrice);
     });
     it("revert when protocol paused", async function () {
       await this.oracleBasement.pause();
@@ -343,12 +358,16 @@ describe("Oracle plugin frame unit tests", function () {
     });
     it("check price with/without pivot oracle", async function () {
       await this.mainOracle.setPrice(token1, 1000);
+      await this.mainOracle.setPrice(token3, 2000);
       await this.boundValidator.setValidateResult(token1, false);
+      await this.boundValidator.setValidateResult(token3, false);
       // empty pivot oracle
       await this.oracleBasement.setOracle(asset1, addr0000, 1);
-      const price = await this.oracleBasement.getUnderlyingPrice(token1);
-      expect(price).to.equal(1000);
-
+      await this.oracleBasement.setOracle(asset3, addr0000, 1);
+      const price1 = await this.oracleBasement.getUnderlyingPrice(token1);
+      expect(price1).to.equal(1000);
+      const price3 = await this.oracleBasement.getUnderlyingPrice(token3);
+      expect(price3).to.equal(2000);
       // set oracle back
       await this.oracleBasement.setOracle(asset1, this.pivotOracle.address, 1);
       await this.mainOracle.setPrice(token1, 1000);
@@ -360,20 +379,29 @@ describe("Oracle plugin frame unit tests", function () {
 
     it("disable pivot oracle", async function () {
       await this.mainOracle.setPrice(token1, 1000);
+      await this.mainOracle.setPrice(token3, 2000);
       // pivot passes the price...
       await this.boundValidator.setValidateResult(token1, true);
+      await this.boundValidator.setValidateResult(token3, true);
       // ...but pivot is disabled, so it won't come to invalidate
       await this.oracleBasement.enableOracle(asset1, 1, false);
-      const price = await this.oracleBasement.getUnderlyingPrice(token1);
-      expect(price).to.equal(1000);
+      await this.oracleBasement.enableOracle(asset3, 1, false);
+      const price1 = await this.oracleBasement.getUnderlyingPrice(token1);
+      expect(price1).to.equal(1000);
+      const price3 = await this.oracleBasement.getUnderlyingPrice(token3);
+      expect(price3).to.equal(2000);
     });
 
     it("enable fallback oracle", async function () {
       await this.mainOracle.setPrice(token2, 1000);
+      await this.mainOracle.setPrice(token3, 2000);
       // invalidate the price first
       await this.pivotOracle.setPrice(token2, 1000);
+      await this.pivotOracle.setPrice(token3, 2000);
       await this.boundValidator.setValidateResult(token2, false);
+      await this.boundValidator.setValidateResult(token3, false);
       await expect(this.oracleBasement.getUnderlyingPrice(token2)).to.be.revertedWith("invalid resilient oracle price");
+      await expect(this.oracleBasement.getUnderlyingPrice(token3)).to.be.revertedWith("invalid resilient oracle price");
 
       // enable fallback oracle
       await this.mainOracle.setPrice(token2, 0);

--- a/test/ResilientOracle.ts
+++ b/test/ResilientOracle.ts
@@ -38,13 +38,13 @@ describe("Oracle plugin frame unit tests", function () {
     this.fallbackOracle = await getSimpleOracle(admin);
     this.boundValidator = await getBoundValidator(admin);
     this.vBnb = signers[5].address;
-    this.bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+    this.bnbAddr = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
   });
 
   beforeEach(async function () {
     const ResilientOracle = await ethers.getContractFactory("ResilientOracle", this.admin);
     const instance = <ResilientOracle>await upgrades.deployProxy(ResilientOracle, [this.boundValidator.address], {
-        constructorArgs: [this.vBnb],
+      constructorArgs: [this.vBnb],
     });
     this.oracleBasement = instance;
   });


### PR DESCRIPTION
## Description

- Refactored getUnderlyingPrice function to reduce contract calls, reduce memory storage, and lines of code. This will optimize gas usage whenever the function is used in a state change function in the protocol. Also saves deployment costs.
- Peckshield audit fixes: https://www.notion.so/Peckshield-Oracle-d6b9f1c636a84be4993141bf7eca8e52
- Audit fixes include one critical bug where the vBNB token not having an underlying token function would have broken all the oracle.getUnderlyingPrice for vBNB. All oracles now store an immutable vBNB address and the underlying asset of BNB with address: `0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB` . The only exception is the TWAP oracle for which the underlying asset is wBNB. This should be kept in mind when storing asset config and prices. Tests are updated accordingly.
- Updated and added more tests.
- Improve documentation with better natspec comments.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
