### PR TITLE
Fix Mock Oracle

### DIFF
--- a/contracts/oracles/mocks/MockBinanceOracle.sol
+++ b/contracts/oracles/mocks/MockBinanceOracle.sol
@@ -22,6 +22,7 @@ contract MockBinanceOracle is OwnableUpgradeable {
     }
 
     function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        return assetPrices[vToken];
+        address token = VBep20Interface(vToken).underlying();
+        return assetPrices[token];
     }
 }

--- a/contracts/oracles/mocks/MockTwapOracle.sol
+++ b/contracts/oracles/mocks/MockTwapOracle.sol
@@ -25,6 +25,7 @@ contract MockTwapOracle is OwnableUpgradeable {
 
     //https://compound.finance/docs/prices
     function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        return assetPrices[vToken];
+        address token = VBep20Interface(vToken).underlying();
+        return assetPrices[token];
     }
 }

--- a/deploy/2-configure-feeds.ts
+++ b/deploy/2-configure-feeds.ts
@@ -58,7 +58,7 @@ const assets: Assets = {
       token: "BTCB",
       address: "0xA808e341e8e723DC6BA0Bb5204Bafc2330d7B8e4",
       oracle: "chainlink",
-      price: "159990000000000000000",
+      price: "208000000000000000",
     },
     {
       token: "XVS",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@venusprotocol/oracle",
   "description": "Venus Protocol Price Oracle",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "author": "",
   "files": [
     "artifacts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@venusprotocol/oracle",
   "description": "Venus Protocol Price Oracle",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "author": "",
   "files": [
     "artifacts",

--- a/test/fork/core-compatibility.ts
+++ b/test/fork/core-compatibility.ts
@@ -119,7 +119,7 @@ describe("Core protocol", async () => {
       await chainlinkOracle.setTokenConfig({
         asset: BNBAddress,
         feed: "0x0567F2323251f0Aab15c8dFb1967E4e8A7D42aeE",
-        maxStalePeriod: 86400,
+        maxStalePeriod: 864000,
       });
 
       await resilientOracle.setTokenConfig({
@@ -140,7 +140,7 @@ describe("Core protocol", async () => {
       await chainlinkOracle.setTokenConfig({
         asset: LTCAddress,
         feed: "0x74e72f37a8c415c8f1a98ed42e78ff997435791d",
-        maxStalePeriod: 86400,
+        maxStalePeriod: 864000,
       });
 
       await resilientOracle.setTokenConfig({
@@ -161,7 +161,7 @@ describe("Core protocol", async () => {
       await chainlinkOracle.setTokenConfig({
         asset: XVSAddress,
         feed: "0xbf63f430a79d4036a5900c19818aff1fa710f206",
-        maxStalePeriod: 86400,
+        maxStalePeriod: 864000,
       });
 
       await resilientOracle.setTokenConfig({
@@ -179,7 +179,7 @@ describe("Core protocol", async () => {
       await chainlinkOracle.setTokenConfig({
         asset: VAI,
         feed: "0x058316f8bb13acd442ee7a216c7b60cfb4ea1b53",
-        maxStalePeriod: 86400,
+        maxStalePeriod: 864000,
       });
 
       await resilientOracle.setTokenConfig({


### PR DESCRIPTION
## Description

The Binance and Twap mock oracle are were use the vToken to get the price instead they should use the underlying asset to read its price.

Resolves #<!-- issue id -->

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
