### PR TITLE
fix: update version to trigger semantic-release and prettierignore the changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,5 @@ coverage.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+CHANGELOG.md
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@venusprotocol/oracle",
   "description": "Venus Protocol Price Oracle",
-  "version": "1.0.0-dev.1",
+  "version": "1.6.11-dev.1",
   "author": "",
   "engines": {
     "node": ">=14.x.x"


### PR DESCRIPTION
This PR:
* restores the original version (1.6.11-dev.1)
* adds `CHANGELOG.md` to `.prettierignore` so that linting passes