### PR TITLE
fix: remove postinstall script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         # Hack to get around failing "ethereumjs-abi The remote archive doesn't match the expected checksum" error
         run: YARN_CHECKSUM_BEHAVIOR=update yarn
 
+      - name: Compile contract types
+        run: yarn hardhat compile
+
       - name: Lint solidity and ts files
         run: yarn lint
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "test": "npm run compile && hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain",
     "build": "rm -rf dist && tsc --declaration && hardhat compile",
-    "postinstall": "yarn build",
     "publish": "yarn build && yarn npm publish",
     "docgen": "hardhat docgen",
     "prepare": "husky install"


### PR DESCRIPTION
## Description

Remove postinstall script because it prevents installation and isn't required