### PR TITLE
ci: Always auth npm

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,7 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
 
 yarnPath: .yarn/releases/yarn-3.2.0.cjs
+
+npmScopes:
+  venusprotocol:
+    npmAlwaysAuth: true


### PR DESCRIPTION
## Description

CD errors with an authentication issue but still publishes the package. This PR is to see if always authenticating silences the error