### PR TITLE
ci: remove publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "test": "npm run compile && hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain",
     "build": "rm -rf dist && tsc --declaration && hardhat compile",
-    "publish": "yarn build && yarn npm publish",
     "docgen": "hardhat docgen",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Description

Remove publish script. We'll use the default yarn publish command and build as a separate step