### PR TITLE
fix: define getPrice from the new OracleInterface in mock contracts

### DIFF
--- a/contracts/oracles/mocks/MockBinanceOracle.sol
+++ b/contracts/oracles/mocks/MockBinanceOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "../../interfaces/VBep20Interface.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OracleInterface } from "../../interfaces/OracleInterface.sol";
 
-contract MockBinanceOracle is OwnableUpgradeable {
+contract MockBinanceOracle is OwnableUpgradeable, OracleInterface {
     mapping(address => uint256) public assetPrices;
 
     constructor() {}
@@ -15,8 +15,7 @@ contract MockBinanceOracle is OwnableUpgradeable {
 
     function initialize() public initializer {}
 
-    function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        address token = VBep20Interface(vToken).underlying();
+    function getPrice(address token) public view returns (uint256) {
         return assetPrices[token];
     }
 }

--- a/contracts/oracles/mocks/MockChainlinkOracle.sol
+++ b/contracts/oracles/mocks/MockChainlinkOracle.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "../ChainlinkOracle.sol";
-import "../../interfaces/VBep20Interface.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OracleInterface } from "../../interfaces/OracleInterface.sol";
 
-contract MockChainlinkOracle is OwnableUpgradeable {
+contract MockChainlinkOracle is OwnableUpgradeable, OracleInterface {
     mapping(address => uint256) public assetPrices;
 
     //set price in 6 decimal precision
@@ -20,8 +19,7 @@ contract MockChainlinkOracle is OwnableUpgradeable {
     }
 
     //https://compound.finance/docs/prices
-    function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        address token = VBep20Interface(vToken).underlying();
+    function getPrice(address token) public view returns (uint256) {
         return assetPrices[token];
     }
 }

--- a/contracts/oracles/mocks/MockPythOracle.sol
+++ b/contracts/oracles/mocks/MockPythOracle.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "../PythOracle.sol";
-import "../../interfaces/VBep20Interface.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IPyth } from "../PythOracle.sol";
+import { OracleInterface } from "../../interfaces/OracleInterface.sol";
 
 contract MockPythOracle is OwnableUpgradeable {
     mapping(address => uint256) public assetPrices;
@@ -25,8 +25,7 @@ contract MockPythOracle is OwnableUpgradeable {
     }
 
     //https://compound.finance/docs/prices
-    function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        address token = VBep20Interface(vToken).underlying();
+    function getPrice(address token) public view returns (uint256) {
         return assetPrices[token];
     }
 }

--- a/contracts/oracles/mocks/MockTwapOracle.sol
+++ b/contracts/oracles/mocks/MockTwapOracle.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "../../interfaces/VBep20Interface.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OracleInterface } from "../../interfaces/OracleInterface.sol";
 
 contract MockTwapOracle is OwnableUpgradeable {
     mapping(address => uint256) public assetPrices;
@@ -24,8 +24,7 @@ contract MockTwapOracle is OwnableUpgradeable {
     }
 
     //https://compound.finance/docs/prices
-    function getUnderlyingPrice(address vToken) public view returns (uint256) {
-        address token = VBep20Interface(vToken).underlying();
+    function getPrice(address token) public view returns (uint256) {
         return assetPrices[token];
     }
 }


### PR DESCRIPTION
The ResilientOracle has been updated to use getPrice instead of getUnderlyingPrice from the inner oracles. However, mocks haven't been updated, causing "invalid resilient oracle price" error in IL integration tests.

This PR replaces getUndrelyingPrice with getPrice in mock contracts.