### PR TITLE
feat: migrate to 0.8.20

### DIFF
--- a/contracts/ResilientOracle.sol
+++ b/contracts/ResilientOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2022 Venus
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "./interfaces/VBep20Interface.sol";

--- a/contracts/interfaces/FeedRegistryInterface.sol
+++ b/contracts/interfaces/FeedRegistryInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface FeedRegistryInterface {
     function latestRoundDataByName(

--- a/contracts/interfaces/IStETH.sol
+++ b/contracts/interfaces/IStETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IStETH {
     function getPooledEthByShares(uint256 _sharesAmount) external view returns (uint256);

--- a/contracts/interfaces/OracleInterface.sol
+++ b/contracts/interfaces/OracleInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface OracleInterface {
     function getPrice(address asset) external view returns (uint256);

--- a/contracts/interfaces/PublicResolverInterface.sol
+++ b/contracts/interfaces/PublicResolverInterface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2022 Venus
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface PublicResolverInterface {
     function addr(bytes32 node) external view returns (address payable);

--- a/contracts/interfaces/PythInterface.sol
+++ b/contracts/interfaces/PythInterface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021 Pyth Data Foundation
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 contract PythStructs {
     // A price with a degree of uncertainty, represented as a price +- a confidence interval.

--- a/contracts/interfaces/SIDRegistryInterface.sol
+++ b/contracts/interfaces/SIDRegistryInterface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2022 Venus
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface SIDRegistryInterface {
     function resolver(bytes32 node) external view returns (address);

--- a/contracts/interfaces/VBep20Interface.sol
+++ b/contracts/interfaces/VBep20Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 

--- a/contracts/oracles/BinanceOracle.sol
+++ b/contracts/oracles/BinanceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "../interfaces/VBep20Interface.sol";

--- a/contracts/oracles/BoundValidator.sol
+++ b/contracts/oracles/BoundValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/VBep20Interface.sol";
 import "../interfaces/OracleInterface.sol";

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/VBep20Interface.sol";
 import "../interfaces/OracleInterface.sol";

--- a/contracts/oracles/PythOracle.sol
+++ b/contracts/oracles/PythOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin/contracts/utils/math/SignedMath.sol";

--- a/contracts/oracles/WstETHOracle.sol
+++ b/contracts/oracles/WstETHOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { OracleInterface } from "../interfaces/OracleInterface.sol";
 import { IStETH } from "../interfaces/IStETH.sol";

--- a/contracts/oracles/mocks/MockBinanceFeedRegistry.sol
+++ b/contracts/oracles/mocks/MockBinanceFeedRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../../interfaces/FeedRegistryInterface.sol";
 

--- a/contracts/oracles/mocks/MockBinanceOracle.sol
+++ b/contracts/oracles/mocks/MockBinanceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { OracleInterface } from "../../interfaces/OracleInterface.sol";

--- a/contracts/oracles/mocks/MockChainlinkOracle.sol
+++ b/contracts/oracles/mocks/MockChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { OracleInterface } from "../../interfaces/OracleInterface.sol";

--- a/contracts/oracles/mocks/MockPythOracle.sol
+++ b/contracts/oracles/mocks/MockPythOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { IPyth } from "../PythOracle.sol";

--- a/contracts/test/AccessControlManager.sol
+++ b/contracts/test/AccessControlManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@venusprotocol/governance-contracts/contracts/Governance/AccessControlManager.sol";
 

--- a/contracts/test/BEP20Harness.sol
+++ b/contracts/test/BEP20Harness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/MockPyth.sol
+++ b/contracts/test/MockPyth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/PythInterface.sol";
 

--- a/contracts/test/MockSimpleOracle.sol
+++ b/contracts/test/MockSimpleOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/OracleInterface.sol";
 

--- a/contracts/test/MockV3Aggregator.sol
+++ b/contracts/test/MockV3Aggregator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
 

--- a/contracts/test/PancakePairHarness.sol
+++ b/contracts/test/PancakePairHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 // a library for performing various math operations
 

--- a/contracts/test/VBEP20Harness.sol
+++ b/contracts/test/VBEP20Harness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "./BEP20Harness.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.13",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
This PR updates the pragma to:

* `^0.8.20` for interfaces, constants, etc.
* `0.8.20` for anything that contains code

Before merging, the dependencies have to be updated after https://github.com/VenusProtocol/solidity-utilities/pull/17 and https://github.com/VenusProtocol/governance-contracts/pull/61 are merged.