### PR TITLE
chore: specify paris hardfork explicitly

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,6 +62,7 @@ const config: HardhatUserConfig = {
               yul: !process.env.CI,
             },
           },
+          evmVersion: "paris",
           outputSelection: {
             "*": {
               "*": ["storageLayout"],


### PR DESCRIPTION
Although hardhat uses paris by default for solc >=0.8.20, this might not be the case in future versions of hardhat. It's better to specify the hardfork explicitly, and update it when the chains are ready.